### PR TITLE
uses the user login id to anonymize the user logins

### DIFF
--- a/RockSweeper/SweeperController.DataScrubbing.partial.cs
+++ b/RockSweeper/SweeperController.DataScrubbing.partial.cs
@@ -552,13 +552,19 @@ namespace RockSweeper
                 {
                     var changes = new Dictionary<string, object>
                     {
-                        { "UserName", GenerateFakeLoginForLogin( login.Item2 ) }
+                        { "UserName", $"fakeuser{ login.Item1 }" }
                     };
 
-                    bulkChanges.Add( new Tuple<int, Dictionary<string, object>>( login.Item1, changes ) );
+                    if (login.Item2 != changes.First().Value.ToString())
+                    {
+                        bulkChanges.Add(new Tuple<int, Dictionary<string, object>>(login.Item1, changes));
+                    }   
                 }
 
-                UpdateDatabaseRecords( "UserLogin", bulkChanges );
+                if (bulkChanges.Count() > 0)
+                {
+                    UpdateDatabaseRecords("UserLogin", bulkChanges);
+                }
             }, ( p ) =>
             {
                 Progress( p );

--- a/RockSweeper/SweeperController.partial.cs
+++ b/RockSweeper/SweeperController.partial.cs
@@ -80,13 +80,6 @@ namespace RockSweeper
         /// </value>
         private ConcurrentDictionary<string, string> PhoneMap { get; set; }
 
-        /// <summary>
-        /// Gets the map of original login names to new scrubbed login names.
-        /// </summary>
-        /// <value>
-        /// The map of original login names to new scrubbed login names.
-        /// </value>
-        private ConcurrentDictionary<string, string> LoginMap { get; set; }
 
         /// <summary>
         /// Gets the faker object that will help generate fake data.
@@ -131,7 +124,6 @@ namespace RockSweeper
 
             EmailMap = new ConcurrentDictionary<string, string>();
             PhoneMap = new ConcurrentDictionary<string, string>();
-            LoginMap = new ConcurrentDictionary<string, string>();
 
             GeoLookupCache = new ConcurrentDictionary<string, Address>( Support.LoadGeocodeCache() );
 
@@ -226,23 +218,6 @@ namespace RockSweeper
             return email;
         }
 
-        /// <summary>
-        /// Generates the fake login for the real login.
-        /// </summary>
-        /// <param name="originalLogin">The original login.</param>
-        /// <returns></returns>
-        protected string GenerateFakeLoginForLogin( string originalLogin )
-        {
-            string login = LoginMap.GetOrAdd( originalLogin.ToLower(), ( key ) =>
-            {
-                lock ( LoginMap )
-                {
-                    return $"fakeuser{ LoginMap.Count + 1 }";
-                }
-            } );
-
-            return login;
-        }
 
         /// <summary>
         /// Generates the fake phone for the real phone number.


### PR DESCRIPTION
Changes the `UserLogin` sanitizer to just reference the database `id` of the `UserLogin` when sanitizing to `fakeuser#`. Speed increased overall with not using the extra list and only inserting needed updates.

Reason:
I ran into issues where it was getting duplicate value db contraint errors on our dataset. I think it was something in the logic where it was iterating strange or some sort of race condition where it got back to an already entered fake id. Feel free to reject if you want and I will just put it on our fork's master. Thanks for the work you did on this. It save me a bunch of effort.